### PR TITLE
Annotate the type of 'variables' in class All and class None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* Annotate the type of 'variables' in class All and class None.
+
 ## 1.0.2
 
 * Declare compatibility with `string_scanner` 1.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.3
 
-* Annotate the type of 'variables' in class All and class None.
+* Work around an inference bug in the new common front-end.
 
 ## 1.0.2
 

--- a/lib/src/all.dart
+++ b/lib/src/all.dart
@@ -6,7 +6,9 @@ import '../boolean_selector.dart';
 
 /// A selector that matches all inputs.
 class All implements BooleanSelector {
-  final List<String> variables = const [];
+  // TODO(nweiz): Stop explicitly providing a type argument when sdk#32412 is
+  // fixed.
+  final variables = const <String>[];
 
   const All();
 

--- a/lib/src/all.dart
+++ b/lib/src/all.dart
@@ -6,7 +6,7 @@ import '../boolean_selector.dart';
 
 /// A selector that matches all inputs.
 class All implements BooleanSelector {
-  final variables = const [];
+  final List<String> variables = const [];
 
   const All();
 

--- a/lib/src/none.dart
+++ b/lib/src/none.dart
@@ -6,7 +6,9 @@ import '../boolean_selector.dart';
 
 /// A selector that matches no inputs.
 class None implements BooleanSelector {
-  final List<String> variables = const [];
+  // TODO(nweiz): Stop explicitly providing a type argument when sdk#32412 is
+  // fixed.
+  final variables = const <String>[];
 
   const None();
 

--- a/lib/src/none.dart
+++ b/lib/src/none.dart
@@ -6,7 +6,7 @@ import '../boolean_selector.dart';
 
 /// A selector that matches no inputs.
 class None implements BooleanSelector {
-  final variables = const [];
+  final List<String> variables = const [];
 
   const None();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: boolean_selector
-version: 1.0.4-dev
+version: 1.0.3
 description: A flexible syntax for boolean expressions.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/boolean_selector

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: boolean_selector
-version: 1.0.3-dev
+version: 1.0.4-dev
 description: A flexible syntax for boolean expressions.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/boolean_selector


### PR DESCRIPTION
Annotate the type of 'variables' in class All and class None to ensure that we do not run into https://github.com/dart-lang/sdk/issues/32412