### PR TITLE
Rename _getNext to _readNext

### DIFF
--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -40,14 +40,14 @@ class Scanner {
   ///
   /// Throws a [StateError] if a [TokenType.endOfFile] token has already been
   /// consumed.
-  Token peek() => _next ??= _getNext();
+  Token peek() => _next ??= _readNext();
 
   /// Consumes and returns the next token in the stream.
   ///
   /// Throws a [StateError] if a [TokenType.endOfFile] token has already been
   /// consumed.
   Token next() {
-    var token = _next ?? _getNext();
+    var token = _next ?? _readNext();
     _endOfFileEmitted = token.type == TokenType.endOfFile;
     _next = null;
     return token;
@@ -65,7 +65,7 @@ class Scanner {
   }
 
   /// Scan and return the next token in the stream.
-  Token _getNext() {
+  Token _readNext() {
     if (_endOfFileEmitted) throw StateError('No more tokens.');
 
     _consumeWhitespace();


### PR DESCRIPTION
"read" is more descriptive since it generally falls through to something
which reads from `_scanner` and changes state. Follows
https://dart.dev/guides/language/effective-dart/design#avoid-starting-a-method-name-with-get