### PR TITLE
update for the 2.10 dev sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,28 @@
 language: dart
 
 dart:
-- dev
+- preview/raw/2.10.0-0.2-dev
 
 jobs:
   include:
     - stage: analyze_and_format
       name: "Analyze"
-      dart: dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos .
     - stage: analyze_and_format
       name: "Format"
-      dart: dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: dartfmt -n --set-exit-if-changed .
     - stage: test
       name: "Vm Tests"
-      dart: dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p vm 
     - stage: test
       name: "Web Tests"
-      dart: dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p chrome
 
@@ -32,7 +32,7 @@ stages:
 
 # Only building master means that we don't run two builds for each pull request.
 branches:
-  only: [master, null_safety]
+  only: [master]
 
 cache:
   directories:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,8 @@ description: >-
 homepage: https://github.com/dart-lang/boolean_selector
 
 environment:
-  sdk: '>=2.9.0-18.0 <2.9.0'
+  # This must remain a tight constraint until nnbd is stable
+  sdk: '>=2.10.0-0 <2.10.0'
 
 dependencies:
   source_span: '>=1.8.0-nullsafety <1.8.0'
@@ -20,75 +21,54 @@ dev_dependencies:
 
 dependency_overrides:
   async:
-    git:
-      url: git://github.com/dart-lang/async.git
-      ref: null_safety
+    git: git://github.com/dart-lang/async.git
   charcode:
-    git:
-      url: git://github.com/dart-lang/charcode.git
-      ref: null_safety
-  collection: 1.15.0-nullsafety
+    git: git://github.com/dart-lang/charcode.git
+  collection:
+    git: git://github.com/dart-lang/collection.git
   js:
     git:
       url: git://github.com/dart-lang/sdk.git
       path: pkg/js
+      ref: 2-10-pkgs
   matcher:
+    git: git://github.com/dart-lang/matcher.git
+  meta:
     git:
-      url: git://github.com/dart-lang/matcher.git
-      ref: null_safety
-  meta: 1.3.0-nullsafety
+      url: git://github.com/dart-lang/sdk.git
+      path: pkg/meta
+      ref: 2-10-pkgs
   path:
-    git:
-      url: git://github.com/dart-lang/path.git
-      ref: null_safety
+    git: git://github.com/dart-lang/path.git
   pedantic:
-    git:
-      url: git://github.com/dart-lang/pedantic.git
-      ref: null_safety
+    git: git://github.com/dart-lang/pedantic.git
   pool:
-    git:
-      url: git://github.com/dart-lang/pool.git
-      ref: null_safety
+    git: git://github.com/dart-lang/pool.git
   source_maps:
-    git:
-      url: git://github.com/dart-lang/source_maps.git
-      ref: null_safety
+    git: git://github.com/dart-lang/source_maps.git
   source_map_stack_trace:
-    git:
-      url: git://github.com/dart-lang/source_map_stack_trace.git
-      ref: null_safety
+    git: git://github.com/dart-lang/source_map_stack_trace.git
   source_span:
-    git:
-      url: git://github.com/dart-lang/source_span.git
-      ref: null_safety
+    git: git://github.com/dart-lang/source_span.git
   stack_trace:
-    git:
-      url: git://github.com/dart-lang/stack_trace.git
-      ref: null_safety
+    git: git://github.com/dart-lang/stack_trace.git
   stream_channel:
-    git:
-      url: git://github.com/dart-lang/stream_channel.git
-      ref: null_safety
+    git: git://github.com/dart-lang/stream_channel.git
   string_scanner:
-    git:
-      url: git://github.com/dart-lang/string_scanner.git
-      ref: null_safety
+    git: git://github.com/dart-lang/string_scanner.git
   term_glyph:
-    git:
-      url: git://github.com/dart-lang/term_glyph.git
-      ref: null_safety
+    git: git://github.com/dart-lang/term_glyph.git
   test_api:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test_api
   test_core:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test_core
   test:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test
+  typed_data:
+    git: git://github.com/dart-lang/typed_data.git


### PR DESCRIPTION
This is in preparation for the actual 2.10 dev sdk release.

The tests are going to be failing until we update all transitive deps in a similar fashion (they need to declare a 2.10 language version).

The plan for lack of a better option is to just do these all as quickly as possible (and merge them into master), and then go re-run the travis jobs to get the build green again afterwords.