### PR TITLE
Prepare for the 2.11 dev SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0-nullsafety.1
+
+* Allow 2.10 stable and 2.11.0 dev SDK versions.
+
 ## 2.1.0-nullsafety
 
 * Migrate to null safety. There are no expected semantic changes.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: boolean_selector
-version: 2.1.0-nullsafety
+version: 2.1.0-nullsafety.1
 description: >-
   A flexible syntax for boolean expressions, based on a simplified version of
   Dart's expression syntax.
@@ -7,7 +7,7 @@ homepage: https://github.com/dart-lang/boolean_selector
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-0 <2.11.0'
 
 dependencies:
   source_span: '>=1.8.0-nullsafety <1.8.0'


### PR DESCRIPTION
Bump the upper bound to allow 2.10 stable and 2.11.0 dev SDK versions.