### PR TITLE
Bump SDK constraints for pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.0-nullsafety.3
+
+* Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release
+  guidelines.
+
 ## 2.1.0-nullsafety.2
 
 * Allow prerelease versions of the 2.12 sdk.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,12 @@
 name: boolean_selector
-version: 2.1.0-nullsafety.2
+version: 2.1.0-nullsafety.3
 description: >-
   A flexible syntax for boolean expressions, based on a simplified version of
   Dart's expression syntax.
 homepage: https://github.com/dart-lang/boolean_selector
 
 environment:
-  # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.12.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   source_span: '>=1.8.0-nullsafety <1.8.0'


### PR DESCRIPTION
Use a 2.12.0 lower bound since pub does not understand allowed
experiments for earlier versions.

Use a 3.0.0 upper bound to avoid a warning in pub and to give some
flexibility in publishing for stable.